### PR TITLE
chore: read config from application env for OpenAI and Azure adapters [gem-144]

### DIFF
--- a/lib/instructor/adapters/azure.ex
+++ b/lib/instructor/adapters/azure.ex
@@ -232,13 +232,18 @@ defmodule Instructor.Adapters.Azure do
   defp config(base_config, params) do
     model = Keyword.get(params, :model, @default_model)
 
-    default_config = [
-      api_url: System.fetch_env!("AZURE_API_URL"),
-      api_path: "/openai/deployments/#{model}/chat/completions?api-version=2025-01-01-preview",
-      api_key: System.fetch_env!("AZURE_API_KEY"),
-      auth_mode: :api_key_header,
-      http_options: [receive_timeout: 60_000]
-    ]
+    default_config =
+      Keyword.merge(
+        [
+          api_url: System.fetch_env!("AZURE_API_URL"),
+          api_path:
+            "/openai/deployments/#{model}/chat/completions?api-version=2025-01-01-preview",
+          api_key: System.fetch_env!("AZURE_API_KEY"),
+          auth_mode: :api_key_header,
+          http_options: [receive_timeout: 60_000]
+        ],
+        Application.get_env(:instructor, :azure, [])
+      )
 
     Keyword.merge(default_config, base_config)
   end

--- a/lib/instructor/adapters/openai.ex
+++ b/lib/instructor/adapters/openai.ex
@@ -224,13 +224,17 @@ defmodule Instructor.Adapters.OpenAI do
   defp config(nil), do: config(Application.get_env(:instructor, :openai, []))
 
   defp config(base_config) do
-    default_config = [
-      api_url: "https://api.openai.com",
-      api_path: "/v1/chat/completions",
-      api_key: System.get_env("OPENAI_API_KEY"),
-      auth_mode: :bearer,
-      http_options: [receive_timeout: 60_000]
-    ]
+    default_config =
+      Keyword.merge(
+        [
+          api_url: "https://api.openai.com",
+          api_path: "/v1/chat/completions",
+          api_key: System.get_env("OPENAI_API_KEY"),
+          auth_mode: :bearer,
+          http_options: [receive_timeout: 60_000]
+        ],
+        Application.get_env(:instructor, :openai, [])
+      )
 
     Keyword.merge(default_config, base_config)
   end


### PR DESCRIPTION
- Reads the adapters config from the application if present
- Fallbacks to the default one if not

Format:
```elixir
config :instructor,
  adapter: Instructor.Adapters.OpenAI,
  openai: [
    api_key:
      ""
  ],
  azure: [
    api_url: "",
    api_key: ""
  ]
```